### PR TITLE
Docker/analyzer

### DIFF
--- a/analyzer/Dockerfile
+++ b/analyzer/Dockerfile
@@ -23,7 +23,7 @@ RUN useradd -m -u $UID -g $GID -o -s /bin/bash $UNAME || usermod -u $UID $UNAME
 # Copy all files from GREBE/analyzer repository.
 RUN mkdir -p $WORKDIR
 ADD ./* $WORKDIR
-ADD ./src $WORKDIR
+COPY ./src $WORKDIR/src
 
 WORKDIR $WORKDIR
 # Install latest stable LLVM from upstream.

--- a/analyzer/Dockerfile
+++ b/analyzer/Dockerfile
@@ -10,6 +10,7 @@ RUN apt install -y libstdc++-10-dev \
     patch \
     cmake \
     lsb-release software-properties-common gnupg \
+    flex bison build-essential bc libssl-dev libelf-dev \
     g++
 
 ARG WORKDIR=/workspace/

--- a/analyzer/Dockerfile
+++ b/analyzer/Dockerfile
@@ -1,3 +1,7 @@
+### Usage:
+###   docker build -t analyzer --build-arg UID=$(id -u) --build-arg GID=$(id -g) .
+###   docker run --rm -v /host:/host -ti analyzer /bin/bash
+###   user@container:/workspace $ WORKDIR=/workspace KERNEL_SRC=/host/linux KASAN_LOG=/host/kasan.log ./run.sh 
 FROM ubuntu:20.04
 
 ARG DEBIAN_FRONTEND=noninteractive

--- a/analyzer/Dockerfile
+++ b/analyzer/Dockerfile
@@ -1,0 +1,51 @@
+FROM ubuntu:20.04
+
+ARG DEBIAN_FRONTEND=noninteractive
+
+RUN apt-get update -y && apt-get update -y
+RUN apt install -y libstdc++-10-dev \
+    make \
+    wget \
+    xz-utils \
+    patch \
+    cmake \
+    lsb-release software-properties-common gnupg \
+    g++
+
+ARG WORKDIR=/workspace/
+ARG UID=1000
+ARG GID=1000
+ARG UNAME="user"
+# Create user
+RUN groupadd -g $GID -o $UNAME || groupmod -g $GID $UNAME
+RUN useradd -m -u $UID -g $GID -o -s /bin/bash $UNAME || usermod -u $UID $UNAME
+
+# Copy all files from GREBE/analyzer repository.
+RUN mkdir -p $WORKDIR
+ADD ./* $WORKDIR
+ADD ./src $WORKDIR
+
+WORKDIR $WORKDIR
+# Install latest stable LLVM from upstream.
+RUN cd $WORKDIR && bash -c "$(wget -O - https://apt.llvm.org/llvm.sh)"
+
+RUN chown -R $UNAME:$UNAME $WORKDIR
+# Switch from root to regular user.
+USER $UNAME
+
+# Fetch LLVM 10.0.1 source code.
+RUN cd $WORKDIR && wget https://github.com/llvm/llvm-project/releases/download/llvmorg-10.0.1/llvm-project-10.0.1.tar.xz
+RUN cd $WORKDIR && tar -xf llvm-project-*.tar.xz && rm llvm-project-*.tar.xz
+# Apply custom patch to LLVM to generate -O0 bitcode.
+RUN cd llvm-project-* && wget https://raw.githubusercontent.com/Markakd/LLVM-O0-BitcodeWriter/master/WriteBitcode.patch
+RUN cd $WORKDIR && cd llvm-project-* && patch -p 1 < WriteBitcode.patch
+# Compile custom clang compiler which can generate -O0 bitcode.
+RUN cd $WORKDIR && cd llvm-project-* && mkdir -p build && cd build && cmake -DLLVM_ENABLE_PROJECTS=clang -DCMAKE_BUILD_TYPE=Release -G "Unix Makefiles" ../llvm && make -j $(nproc)
+
+# Run make install as root to install LLVM headers.
+USER root
+RUN cd $WORKDIR && cd llvm-project-* && cd build && make install
+# Run the remainder of the build as user to build the analyzer binary.
+USER $UNAME
+RUN cd $WORKDIR && make
+

--- a/analyzer/run.sh
+++ b/analyzer/run.sh
@@ -1,0 +1,94 @@
+#!/bin/bash
+### run.sh - 
+###   Provided the following environment variables as inputs, 
+###   run the GREBE/analyzer workflow to produce the 
+###   object report 'sts.txt':
+###    - WORKDIR=/path/to/GREBE/analyzer/
+###    - KERNEL_SRC=/path/to/linux/src/
+###    - KASAN_LOG=/path/to/kasan_report.log
+set -ex
+
+WORKDIR=${WORKDIR}
+KERNEL_SRC=${KERNEL_SRC}
+KASAN_LOG=${KASAN_LOG}
+
+DEFAULT_WORKDIR=/workspace
+if [ -z ${WORKDIR} ]; then
+    echo "[-] Environment var WORKDIR not set! Defaulting to ${DEFAULT_WORKDIR}..."
+    WORKDIR=${DEFAULT_WORKDIR}
+fi
+
+if [ -z ${KERNEL_SRC} ]; then
+    echo "[-] Environment var KERNEL_SRC not set!"
+    exit 1
+fi
+
+if [ -z ${KASAN_LOG} ]; then
+    echo "[-] Environment var KASAN_LOG not set!"
+    exit 1
+fi
+
+if [[ ! -d ${WORKDIR} ]]; then
+    echo "[-] Could not find WORKDIR=${WORKDIR}!"
+    exit 2
+fi
+
+if [[ ! -d ${KERNEL_SRC} ]]; then
+    echo "[-] Could not find KERNEL_SRC=${KERNEL_SRC}!"
+    exit 2
+fi
+
+if [[ ! -f ${KASAN_LOG} ]]; then
+    echo "[-] Could not find KASAN_LOG=${KASAN_LOG}!"
+    exit 2
+fi
+
+EXPECTED_KASAN=$(realpath ${WORKDIR}/report)
+# GREBE/analyzer/run_analyze.py expects the KASAN log to be named
+#  @ GREBE/analyzer/report
+cp ${KASAN_LOG} ${EXPECTED_KASAN}
+echo "[+] Copied ${KASAN_LOG} -> ${EXPECTED_KASAN}"
+
+ANALYZER_BUILD=$(realpath ${WORKDIR}/build)
+EXPECTED_BUILD=~/kernel_bugs/Github/syzObjkaller/tools/analyzer
+# GREBE/analyzer/run_analyze.py expects GREBE/analyzer/build
+#  @ ~/kernel_bugs/Github/syzObjkaller/tools/analyzer
+mkdir -p ${EXPECTED_BUILD}
+cp -r ${ANALYZER_BUILD} ${EXPECTED_BUILD}
+echo "[+] Copied ${ANALYZER_BUILD} -> ${EXPECTED_BUILD}"
+
+EXPECTED_KERNEL=$(realpath ${WORKDIR}/linux-bitcode)
+# GREBE/analyzer/run_analyze.py expects the Linux kernel source repo
+#  @ GREBE/analyzer/linux-bitcode
+rm -rf ${EXPECTED_KERNEL}
+cp -r ${KERNEL_SRC} ${EXPECTED_KERNEL}
+echo "[+] Copied ${KERNEL_SRC} -> ${EXPECTED_KERNEL}"
+
+#### GREBE/analyzer WORKFLOW BEGIN ####
+## 1. Build Kernel bitcode
+# Build Linux kernel with custom clang and emit unoptimized LLVM bitcode
+echo "[*] Building Linux kernel with custom clang..."
+cd ${EXPECTED_KERNEL} && make CC=clang CFLAGS="-O0 -emit-llvm -flto -save-temps"
+echo "[+] Output unoptimized LLVM bitcode for Linux kernel."
+
+## 2. Parse call graph from KASAN report
+echo "[*] Processing KASAN report..."
+cd ${WORKDIR} && python3 get_cg.py ${EXPECTED_KASAN}
+echo "[+] Finished processing KASAN log."
+EXPECTED_CG=$(realpath ${WORKDIR}/report_cg.txt)
+# Expected output is 'report_cg.txt'
+if [[ ! -f ${EXPECTED_CG} ]]; then
+    echo "[-] get_cg.py failed to produce report_cg.txt from ${EXPECTED_KASAN}!"
+    exit 2
+fi
+
+## 3. Run GREBE/analyzer providing the kernel bitcode, KASAN log, and call graph
+echo "[*] Analyzing kernel bit-code, KASAN log, and call graph..."
+cd ${WORKDIR} && python3 run_analyze.py .
+echo "[+] Finished analysis."
+EXPECTED_OUT=$(realpath ${WORKDIR}/sts.txt)
+# Expected output is 'sts.txt'
+if [[ ! -f ${EXPECTED_OUT} ]]; then
+    echo "[-] run_analyze.py failed to produce ${EXPECTED_OUT}!"
+    exit 2
+fi


### PR DESCRIPTION
Features:
* Streamline runnable environment to run the GREBE analyzer in docker

Hi, I've added a `Dockerfile` and `run.sh` script to make GREBE easier to use for researchers looking to reproduce the research.

I've tested building and running the analyzer in docker on my host running Ubuntu 20.0.4.1 LTS and Docker version 20.10.17 and the `GREBE/analyzer` workflow runs to completion. 

For interested researchers, I've forked the relevant projects that GREBE makes modifications to in order to make it easier to identify those changes. This should be helpful when a researcher might need to duplicate those modifications to a different version of the base software. After all, building kernel versions often requires specific compiler versions.

* [grebe-syzkaller](https://github.com/whoismissing/syzkaller/tree/grebe-syzkaller)
* [grebe-gcc](https://github.com/whoismissing/grebe-gcc/tree/fork/grebe-gcc)